### PR TITLE
Add Flask CRUD interface for nutrient database

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,75 @@
+import csv
+import os
+from flask import Flask, jsonify, request
+
+CSV_FILE = os.environ.get('NUTRIENTS_DB', 'Nutrients DB.csv')
+FIELDNAMES = ['Продукт', 'Белки', 'Насыщенные', 'НЕнасыщенные', 'Простые',
+              'Сложные перевариваемые', 'Растворимая', 'Нерастворимая',
+              'ККал', 'Макс. порций', 'Шаг']
+
+app = Flask(__name__, static_folder='static', static_url_path='')
+
+def _sanitize(row):
+    def clean_key(k: str) -> str:
+        return " ".join(k.replace('\r', ' ').replace('\n', ' ').split())
+    return {clean_key(k): v for k, v in row.items()}
+
+def read_products():
+    products = []
+    with open(CSV_FILE, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            products.append(_sanitize(row))
+    return products
+
+def write_products(products):
+    with open(CSV_FILE, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, FIELDNAMES)
+        writer.writeheader()
+        for p in products:
+            writer.writerow(p)
+
+@app.route('/api/products', methods=['GET'])
+def get_products():
+    return jsonify(read_products())
+
+@app.route('/api/products', methods=['POST'])
+def add_product():
+    data = request.get_json()
+    if not data or any(field not in data or data[field] == '' for field in FIELDNAMES):
+        return jsonify({'error': 'Все поля обязательны'}), 400
+    products = read_products()
+    if any(p['Продукт'] == data['Продукт'] for p in products):
+        return jsonify({'error': 'Продукт уже существует'}), 400
+    products.append({field: data[field] for field in FIELDNAMES})
+    write_products(products)
+    return jsonify({'status': 'created'}), 201
+
+@app.route('/api/products/<string:name>', methods=['PUT'])
+def edit_product(name):
+    data = request.get_json()
+    if not data or any(field not in data or data[field] == '' for field in FIELDNAMES):
+        return jsonify({'error': 'Все поля обязательны'}), 400
+    products = read_products()
+    for idx, p in enumerate(products):
+        if p['Продукт'] == name:
+            products[idx] = {field: data[field] for field in FIELDNAMES}
+            write_products(products)
+            return jsonify({'status': 'updated'})
+    return jsonify({'error': 'Не найдено'}), 404
+
+@app.route('/api/products/<string:name>', methods=['DELETE'])
+def delete_product(name):
+    products = read_products()
+    new_products = [p for p in products if p['Продукт'] != name]
+    if len(new_products) == len(products):
+        return jsonify({'error': 'Не найдено'}), 404
+    write_products(new_products)
+    return jsonify({'status': 'deleted'})
+
+@app.route('/')
+def index():
+    return app.send_static_file('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/static/index.html
+++ b/static/index.html
@@ -41,7 +41,6 @@
   <input name="Сложные перевариваемые" placeholder="Сложные перевариваемые" type="number" step="any" required>
   <input name="Растворимая" placeholder="Растворимая" type="number" step="any" required>
   <input name="Нерастворимая" placeholder="Нерастворимая" type="number" step="any" required>
-  <input name="ККал" placeholder="ККал" type="number" step="any" required>
   <input name="Макс. порций" placeholder="Макс. порций" type="number" step="any" required>
   <input name="Шаг" placeholder="Шаг" type="number" step="any" required>
   <button type="submit">Добавить</button>
@@ -49,6 +48,7 @@
 
 <script>
 const fieldNames = ["Продукт","Белки","Насыщенные","НЕнасыщенные","Простые","Сложные перевариваемые","Растворимая","Нерастворимая","ККал","Макс. порций","Шаг"];
+const inputFieldNames = fieldNames.filter(f => f !== "ККал");
 
 async function fetchProducts(){
   const res = await fetch('/api/products');
@@ -85,7 +85,7 @@ async function deleteProduct(name){
 
 async function editProduct(prod){
   const edited = {};
-  for(const fn of fieldNames){
+  for(const fn of inputFieldNames){
     const val = prompt('Введите ' + fn, prod[fn]);
     if(val === null || val === ''){ alert('Все поля обязательны'); return; }
     edited[fn] = val;
@@ -102,7 +102,7 @@ document.getElementById('addForm').addEventListener('submit', async e => {
   e.preventDefault();
   const formData = new FormData(e.target);
   const obj = {};
-  for(const fn of fieldNames){
+  for(const fn of inputFieldNames){
     const val = formData.get(fn);
     if(!val){ alert('Все поля обязательны'); return; }
     obj[fn] = val;

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<title>Nutrients DB CRUD</title>
+<style>
+  table { border-collapse: collapse; }
+  th, td { border: 1px solid #ccc; padding: 4px; }
+</style>
+</head>
+<body>
+<h1>База продуктов</h1>
+<p>Количество продуктов: <span id="count"></span></p>
+<table id="productsTable">
+  <thead>
+    <tr>
+      <th>Продукт</th>
+      <th>Белки</th>
+      <th>Насыщенные</th>
+      <th>НЕнасыщенные</th>
+      <th>Простые</th>
+      <th>Сложные перевариваемые</th>
+      <th>Растворимая</th>
+      <th>Нерастворимая</th>
+      <th>ККал</th>
+      <th>Макс. порций</th>
+      <th>Шаг</th>
+      <th>Действия</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>
+
+<h2>Добавить продукт</h2>
+<form id="addForm">
+  <input name="Продукт" placeholder="Продукт" required>
+  <input name="Белки" placeholder="Белки" type="number" step="any" required>
+  <input name="Насыщенные" placeholder="Насыщенные" type="number" step="any" required>
+  <input name="НЕнасыщенные" placeholder="НЕнасыщенные" type="number" step="any" required>
+  <input name="Простые" placeholder="Простые" type="number" step="any" required>
+  <input name="Сложные перевариваемые" placeholder="Сложные перевариваемые" type="number" step="any" required>
+  <input name="Растворимая" placeholder="Растворимая" type="number" step="any" required>
+  <input name="Нерастворимая" placeholder="Нерастворимая" type="number" step="any" required>
+  <input name="ККал" placeholder="ККал" type="number" step="any" required>
+  <input name="Макс. порций" placeholder="Макс. порций" type="number" step="any" required>
+  <input name="Шаг" placeholder="Шаг" type="number" step="any" required>
+  <button type="submit">Добавить</button>
+</form>
+
+<script>
+const fieldNames = ["Продукт","Белки","Насыщенные","НЕнасыщенные","Простые","Сложные перевариваемые","Растворимая","Нерастворимая","ККал","Макс. порций","Шаг"];
+
+async function fetchProducts(){
+  const res = await fetch('/api/products');
+  const data = await res.json();
+  const tbody = document.querySelector('#productsTable tbody');
+  tbody.innerHTML = '';
+  data.forEach(p => {
+    const tr = document.createElement('tr');
+    fieldNames.forEach(fn => {
+      const td = document.createElement('td');
+      td.textContent = p[fn];
+      tr.appendChild(td);
+    });
+    const tdAct = document.createElement('td');
+    const btnEdit = document.createElement('button');
+    btnEdit.textContent = 'Редактировать';
+    btnEdit.onclick = () => editProduct(p);
+    const btnDel = document.createElement('button');
+    btnDel.textContent = 'Удалить';
+    btnDel.onclick = () => deleteProduct(p['Продукт']);
+    tdAct.appendChild(btnEdit);
+    tdAct.appendChild(btnDel);
+    tr.appendChild(tdAct);
+    tbody.appendChild(tr);
+  });
+  document.getElementById('count').textContent = data.length;
+}
+
+async function deleteProduct(name){
+  if(!confirm('Удалить ' + name + '?')) return;
+  const res = await fetch('/api/products/' + encodeURIComponent(name), {method:'DELETE'});
+  if(res.ok) fetchProducts();
+}
+
+async function editProduct(prod){
+  const edited = {};
+  for(const fn of fieldNames){
+    const val = prompt('Введите ' + fn, prod[fn]);
+    if(val === null || val === ''){ alert('Все поля обязательны'); return; }
+    edited[fn] = val;
+  }
+  const res = await fetch('/api/products/' + encodeURIComponent(prod['Продукт']), {
+    method: 'PUT',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(edited)
+  });
+  if(res.ok) fetchProducts();
+}
+
+document.getElementById('addForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const formData = new FormData(e.target);
+  const obj = {};
+  for(const fn of fieldNames){
+    const val = formData.get(fn);
+    if(!val){ alert('Все поля обязательны'); return; }
+    obj[fn] = val;
+  }
+  const res = await fetch('/api/products', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(obj)
+  });
+  if(res.ok){
+    e.target.reset();
+    fetchProducts();
+  }else{
+    const err = await res.json();
+    alert(err.error || 'Ошибка');
+  }
+});
+
+fetchProducts();
+</script>
+</body>
+</html>

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,49 @@
+import json
+import shutil
+from pathlib import Path
+import importlib
+
+import pytest
+
+FIELDNAMES = ["Продукт","Белки","Насыщенные","НЕнасыщенные","Простые",
+              "Сложные перевариваемые","Растворимая","Нерастворимая",
+              "ККал","Макс. порций","Шаг"]
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    src = Path(__file__).with_name('Nutrients DB.csv')
+    dst = tmp_path / 'db.csv'
+    shutil.copy(src, dst)
+    monkeypatch.setenv('NUTRIENTS_DB', str(dst))
+    import app
+    importlib.reload(app)
+    return app.app.test_client()
+
+
+def sample_product(name):
+    return {fn: '1' for fn in FIELDNAMES} | {"Продукт": name}
+
+
+def test_crud_flow(client):
+    resp = client.get('/api/products')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    base_count = len(data)
+
+    new_prod = sample_product('Тест')
+    resp = client.post('/api/products', json=new_prod)
+    assert resp.status_code == 201
+
+    resp = client.get('/api/products')
+    assert len(resp.get_json()) == base_count + 1
+
+    updated = sample_product('Тест')
+    updated['Белки'] = '2'
+    resp = client.put('/api/products/Тест', json=updated)
+    assert resp.status_code == 200
+
+    resp = client.delete('/api/products/Тест')
+    assert resp.status_code == 200
+
+    resp = client.get('/api/products')
+    assert len(resp.get_json()) == base_count


### PR DESCRIPTION
## Summary
- build Flask backend providing CRUD endpoints over `Nutrients DB.csv`
- add HTML frontend to list, add, edit, and delete products with count display
- include tests covering product creation, update, and deletion

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1db81ac1c832cb5465f14364fc200