### PR TITLE
Handle newline in complex carbs column

### DIFF
--- a/optimize_nutrients.py
+++ b/optimize_nutrients.py
@@ -1,15 +1,21 @@
 import csv
 import random
 import math
+import re
 
-# Mapping of CSV column names to internal keys
-COMPLEX_KEY = 'Сложные \nперевариваемые'
+
+def _norm(name: str) -> str:
+    """Normalise CSV header by collapsing whitespace."""
+    return re.sub(r"\s+", " ", name).strip()
+
+
+# Mapping of normalised CSV column names to internal keys
 CSV_TO_KEY = {
     'Белки': 'protein',
     'Насыщенные': 'saturatedFat',
     'НЕнасыщенные': 'unsaturatedFat',
     'Простые': 'simpleCarbs',
-    COMPLEX_KEY: 'complexCarbs',
+    'Сложные перевариваемые': 'complexCarbs',
     'Растворимая': 'solubleFiber',
     'Нерастворимая': 'insolubleFiber',
     'ККал': 'calories',
@@ -54,6 +60,7 @@ def load_products(path: str):
     with open(path, encoding='utf-8') as f:
         reader = csv.DictReader(f)
         for row in reader:
+            row = {_norm(k): v for k, v in row.items()}
             nutrients = {CSV_TO_KEY[k]: float(row[k]) for k in CSV_TO_KEY}
             step = float(row['Шаг'])
             max_weight = float(row['Макс. порций']) * step


### PR DESCRIPTION
## Summary
- normalize CSV header names to strip newlines and extra whitespace
- access nutrient values using normalized names to avoid KeyError

## Testing
- `python - <<'PY'
import optimize_nutrients as o
products = o.load_products('Nutrients DB.csv')
print('products', len(products))
print('first', products[0]['name'])
PY`
- `printf "0\n0\n0\n0\n0\n0\n0\n100\n0\n" | python optimize_nutrients.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1f7544024832c9cb8d72b9e53f579