### PR TITLE
Add interactive product pool HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <title>Продукты</title>
+    <style>
+        #db { display: none; margin-top: 10px; }
+        #pool { margin-top: 10px; }
+        label { display: block; }
+    </style>
+</head>
+<body>
+    <label><input type="checkbox" id="toggle-db"> Показать ДБ</label>
+    <div id="db"></div>
+    <h2>Мой пул</h2>
+    <ul id="pool"></ul>
+
+    <script>
+        const dbDiv = document.getElementById('db');
+        const poolUl = document.getElementById('pool');
+
+        document.getElementById('toggle-db').addEventListener('change', function() {
+            dbDiv.style.display = this.checked ? 'block' : 'none';
+        });
+
+        function addToPool(name) {
+            const existing = document.querySelector('#pool li[data-name="' + name + '"]');
+            if (!existing) {
+                const li = document.createElement('li');
+                li.textContent = name;
+                li.setAttribute('data-name', name);
+                poolUl.appendChild(li);
+            }
+        }
+
+        function removeFromPool(name) {
+            const li = document.querySelector('#pool li[data-name="' + name + '"]');
+            if (li) {
+                li.remove();
+            }
+        }
+
+        fetch('Nutrients%20DB.csv')
+            .then(response => response.text())
+            .then(text => {
+                const lines = text.trim().split(/\r?\n/);
+                lines.splice(0, 2); // remove header lines
+                lines.forEach(line => {
+                    if (!line) return;
+                    const cols = line.split(',');
+                    const name = cols[0];
+                    const label = document.createElement('label');
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.addEventListener('change', function() {
+                        if (this.checked) {
+                            addToPool(name);
+                        } else {
+                            removeFromPool(name);
+                        }
+                    });
+                    label.appendChild(checkbox);
+                    label.appendChild(document.createTextNode(' ' + name));
+                    dbDiv.appendChild(label);
+                });
+            });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add index.html interface allowing users to build a pool of products
- load products from Nutrients DB.csv with show/hide database checkbox
- enable selecting products via checkboxes and add/remove from pool

## Testing
- `python - <<'PY'
import re
with open('index.html', encoding='utf-8') as f:
    c=f.read()
assert 'toggle-db' in c, 'toggle checkbox missing'
assert 'Nutrients%20DB.csv' in c, 'CSV fetch missing'
print('All tests passed')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c3443d2f5c832c982dcf5ba57ac42f